### PR TITLE
DHT22 workaround

### DIFF
--- a/lowlevel/nodemcu-dht22/user.lua
+++ b/lowlevel/nodemcu-dht22/user.lua
@@ -31,7 +31,7 @@ gpio_errled = 6
 temp = 0
 humi = 0
 
--- Number of consecutive errors (HTTP, or Wi-Fi)
+-- Number of consecutive errors (HTTP, Wi-Fi, DHT22 reading)
 nerr = 0
 iserr = false
 
@@ -84,6 +84,7 @@ function getsensor()
 end
 
 function cond_dsleep()
+  nerr = 0
   if dsleep_enabled then
     print("Enabling deep sleep for "..dsleep_interval_us.." us...")
     tmr.unregister(0)
@@ -108,7 +109,6 @@ function loop()
       -- Just reboot.
       siren(5)
       cond_dsleep()
-      nerr = 0
       return
     else
       siren(1)

--- a/lowlevel/nodemcu-dht22/user.lua
+++ b/lowlevel/nodemcu-dht22/user.lua
@@ -21,6 +21,7 @@ sleep_tries_ms = 7000
 
 -- Connections
 gpio_dht    = 4
+gpio_errled = 6
 
 -- dweet.io thing id
 --dweet_thing_id = "@DWEET_THING_ID@"
@@ -46,6 +47,23 @@ end
 -- Debug print
 function dbg(msg)
   --print("DEBUG: "..msg)
+end
+
+-- Blink led for signalling errors.
+function siren(iters)
+  lowdelay=0
+  gpio.mode(gpio_errled, gpio.OUTPUT)
+  gpio.write(gpio_errled, gpio.LOW)
+  for i=0,iters,1
+  do
+    gpio.write(gpio_errled, gpio.HIGH)
+    tmr.delay(50000)
+    gpio.write(gpio_errled, gpio.LOW)
+    if lowdelay > 0 then
+      tmr.delay(lowdelay)
+    end
+    lowdelay=750000
+  end
 end
 
 -- DHT22 sensor logic
@@ -88,9 +106,12 @@ function loop()
     print("We have had "..nerr.."/3 consecutive errors")
     if nerr == 3 then
       -- Just reboot.
+      siren(5)
       cond_dsleep()
       nerr = 0
       return
+    else
+      siren(1)
     end
   end
 

--- a/lowlevel/nodemcu-dht22/user.lua
+++ b/lowlevel/nodemcu-dht22/user.lua
@@ -19,8 +19,13 @@ dsleep_interval_us = 60000000
 -- Sleep between retries (and first attempt too)
 sleep_tries_ms = 7000
 
+-- Connections
+gpio_dht    = 4
+
 -- dweet.io thing id
 --dweet_thing_id = "@DWEET_THING_ID@"
+
+-- End of user configuration
 
 temp = 0
 humi = 0
@@ -46,7 +51,7 @@ end
 -- DHT22 sensor logic
 function getsensor()
   DHT = require("dht22_min")
-  DHT.read(4)
+  DHT.read(gpio_dht)
   temp = DHT.getTemperature()
   humi = DHT.getHumidity()
 

--- a/lowlevel/nodemcu-dht22/user.lua
+++ b/lowlevel/nodemcu-dht22/user.lua
@@ -21,6 +21,7 @@ sleep_tries_ms = 7000
 
 -- Connections
 gpio_dht    = 4
+gpio_dhtpwr = 5
 gpio_errled = 6
 
 -- dweet.io thing id
@@ -66,12 +67,19 @@ function siren(iters)
   end
 end
 
--- DHT22 sensor logic
+-- DHT22 sensor logic.
+-- Works around DHT22 problems by turning it on only before reading.
 function getsensor()
+  print("DHT22: powering up")
+  gpio.mode(gpio_dhtpwr, gpio.OUTPUT)
+  gpio.write(gpio_dhtpwr, gpio.HIGH)
+  tmr.delay(1100000)
+  print("DHT22: reading")
   DHT = require("dht22_min")
   DHT.read(gpio_dht)
   temp = DHT.getTemperature()
   humi = DHT.getHumidity()
+  gpio.write(gpio_dhtpwr, gpio.LOW)
 
   if humi == nil then
     print("DHT22: error reading")


### PR DESCRIPTION
DHT22 may have various overheating and/or stability problems.

Since when connected to VCC it is constantly powered even when the ESP8266 is in deep sleep mode, we now connect its VCC pin to GPIO and set it to high right before reading the temperature.

In accordance with the DHT22 datasheet we wait 1.1 s after powering it up before reading it.
### References
- [DHT22 overheating and stability](http://www.kandrsmith.org/RJS/Misc/dht22_first_failure.html)
- [Unplug DHT22 to restore operativity](http://forum.arduino.cc/index.php?topic=355137.0)
- [DHT22 specs](http://www.electrodragon.com/w/DHT22_Digital_Humidity_and_Temperature_Sensor_%28AM2302%29)
